### PR TITLE
Tolerate whitespace when matching language

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,34 +29,34 @@ function plugin(options){
       var str = data.contents.toString();
       //Fenced block start/end
       var end = /```/;
-      var typed = /```([\w\-]+)\r?\n/;
+      var typed = /```(\s*[\w\-]+\s*)\r?\n/;
       var remainder = str;
       var pos = 0;
       var endpos = 0;
-      
+
       var replacements = [];
       while(end.test(remainder)) {
         var match = remainder.match(end);
         var lang = null;
         var isTyped = remainder.match(typed);
         if (isTyped && match.index===isTyped.index) {
-          lang = remainder.match(typed)[1];
+          lang = isTyped[1].trim();
         }
         var prev = pos;
-        
-        var buff = 3 + (lang ? lang.length : 0);
-        
+
+        var buff = 3 + (lang ? isTyped[1].length : 0);
+
         pos = pos + match.index + buff;
         remainder = str.substring(pos);
-        
+
         var ends = remainder.match(end);
         if (ends==null || ends[0] == null) {
           break;
         }
-        
+
         endpos = ends.index;
         replacements.push(str.substring(prev, pos-buff));
-        
+
         remainder = str.substring(pos+endpos+3);
         var code = str.substring(pos,pos+endpos);
         code = code.trim('(\r\n|\n)')
@@ -78,7 +78,7 @@ function plugin(options){
       if (pos < (str.length-1)) {
         replacements.push(str.substring(pos));
       }
-      
+
       files[file].contents = replacements.join('');
       //files[file].contents = '<link rel="stylesheet" href="'+theme+'">\n'+files[file].contents;
       debug(files[file].contents);

--- a/test/fixture/build/index.md
+++ b/test/fixture/build/index.md
@@ -4,5 +4,7 @@ Non code
 
 <pre><code class="js"><span class="hljs-keyword">var</span> t = <span class="hljs-string">'typed code'</span></code></pre>
 
+<pre><code class="js"><span class="hljs-keyword">var</span> t = <span class="hljs-string">'typed code with a space'</span></code></pre>
+
 
 More non code

--- a/test/fixture/expected/index.md
+++ b/test/fixture/expected/index.md
@@ -4,5 +4,7 @@ Non code
 
 <pre><code class="js"><span class="hljs-keyword">var</span> t = <span class="hljs-string">'typed code'</span></code></pre>
 
+<pre><code class="js"><span class="hljs-keyword">var</span> t = <span class="hljs-string">'typed code with a space'</span></code></pre>
+
 
 More non code

--- a/test/fixture/src/index.md
+++ b/test/fixture/src/index.md
@@ -11,5 +11,9 @@ local var = "untyped code"
 var t = 'typed code'
 ```
 
+``` js
+var t = 'typed code with a space'
+```
+
 
 More non code


### PR DESCRIPTION
Github tolerates whitespace before the language for a code block, so

``````
```js
var x;
```
``````

and 

``````
``` js
var x;
```
``````

both generate

``` js
var x;
```

Let's do the same thing.
