### PR TITLE
use minimatch

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,18 +1,7 @@
 var debug = require('debug')('metalsmith-metallic');
-var extname = require('path').extname;
 var hljs = require('highlight.js');
 var entities = require('entities');
-
-/**
- * Check if a `file` is markdown.
- *
- * @param {String} file
- * @return {Boolean}
- */
-
-function markdown(file) {
-    return (/\.md|\.markdown/).test(extname(file));
-}
+var minimatch = require('minimatch');
 
 /**
  * Expose `plugin`.
@@ -29,12 +18,18 @@ module.exports = plugin;
 
 function plugin(options) {
     'use strict';
+    options = options || {}; // called without options
+    var pattern = options.pattern || '**/*.md';
+    var patternOptions = options.patternOptions || {};
+
     hljs.configure(options);
     return function (files, metalsmith, done) {
         setImmediate(done);
         Object.keys(files).forEach(function (file) {
             debug('checking file: %s', file);
-            if (!markdown(file)) { return; }
+            if (!minimatch(file, pattern, patternOptions)) {
+              return;
+            }
             var data = files[file],
                 str = data.contents.toString(),
                 end = /```(.*)/,
@@ -42,7 +37,7 @@ function plugin(options) {
                 pos = 0,
                 endpos = 0,
                 replacements = [];
-            
+
             while (end.test(remainder)) {
                 var match = remainder.match(end),
                     candidate = match[1].trim(),

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
   },
   "dependencies": {
     "debug": "~2.1",
+    "entities": "~1.1",
     "highlight.js": "~8.3",
-    "entities": "~1.1"
+    "minimatch": "^2.0.1"
   },
   "devDependencies": {
     "mocha": "2.x",


### PR DESCRIPTION
Will allow for exclusion of files like this:

```js
  .use(metallic({
    pattern: '!(scratch)/**/*.md',
    patternOptions: { nonegate: true } // use extglob: !(a) = all except a
  }))
```