### PR TITLE
do not strip spaces from code blocks

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,7 @@ function plugin(options) {
                 pos = 0,
                 endpos = 0,
                 replacements = [];
-            
+
             while (end.test(remainder)) {
                 var match = remainder.match(end),
                     candidate = match[1].trim(),
@@ -63,7 +63,7 @@ function plugin(options) {
 
                 remainder = str.substring(pos + endpos + 3);
                 var code = str.substring(pos, pos + endpos);
-                code = code.trim('(\r\n|\n)');
+                code = code.replace(/(^\n|\n$|\r\n$)/g, '');
                 pos = pos + endpos + 3;
                 if (lang === null) {
                     replacements.push('<pre><code class="hljs">' + hljs.highlightAuto(code).value + '</code></pre>');


### PR DESCRIPTION
As this might be useful:

```
    def method(self):
        # bla bla
```

in this context:
```
class Jej:
    def method(self):
        # bla bla
```
