### PR TITLE
Set files contents as string Buffers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,7 @@ function plugin(options) {
                 pos = 0,
                 endpos = 0,
                 replacements = [];
-            
+
             while (end.test(remainder)) {
                 var match = remainder.match(end),
                     candidate = match[1].trim(),
@@ -83,8 +83,8 @@ function plugin(options) {
                 replacements.push(str.substring(pos));
             }
 
-            files[file].contents = replacements.join('');
-            debug(files[file].contents);
+            files[file].contents = new Buffer(replacements.join(''));
+            debug(files[file].contents.toString());
         });
     };
 }

--- a/test/index.js
+++ b/test/index.js
@@ -6,6 +6,16 @@ var fs = require('fs');
 
 
 describe('metalsmith-metallic', function(){
+  it('should set file contents as a buffer', function(done){
+    Metalsmith('test/fixture')
+      .use(metallic())
+      .build(function(err, files){
+        if (err) { return done(err); }
+        assert.strictEqual(files['index.md'].contents instanceof Buffer, true);
+        done();
+      });
+  });
+
   it('should highlight code blocks in markdown files', function(done){
     fs.readFile('test/fixture/expected/index.md', 'utf8', function (err,data) {
       if (err) {
@@ -15,12 +25,12 @@ describe('metalsmith-metallic', function(){
         .use(metallic())
         .build(function(err, files){
           if (err) { return done(err); }
-          assert.equal(data.toString(), files['index.md'].contents);
+          assert.equal(data.toString(), files['index.md'].contents.toString());
           done();
         });
     });
   });
-    
+
   it('should parse code blocks with the no-highlight language in markdown files', function(done){
     fs.readFile('test/fixture/expected/nohighlight.md', 'utf8', function (err,data) {
       if (err) {
@@ -30,12 +40,12 @@ describe('metalsmith-metallic', function(){
         .use(metallic())
         .build(function(err, files){
           if (err) { return done(err); }
-          assert.equal(data.toString(), files['nohighlight.md'].contents);
+          assert.equal(data.toString(), files['nohighlight.md'].contents.toString());
           done();
         });
     });
   });
-    
+
   it('should highlight specific languages as it does in the browser', function(done){
     fs.readFile('test/fixture/expected/csharp.md', 'utf8', function (err,data) {
       if (err) {
@@ -45,9 +55,9 @@ describe('metalsmith-metallic', function(){
         .use(metallic())
         .build(function(err, files){
           if (err) { return done(err); }
-          assert.equal(data.toString(), files['csharp.md'].contents);
+          assert.equal(data.toString(), files['csharp.md'].contents.toString());
           done();
         });
     });
-  });    
+  });
 });


### PR DESCRIPTION
This is a bug fix.  
When setting `contents` in any metalsmith file, it must be a string `Buffer`, otherwise it may break other plugins. This happened with me right now, so I decided to fix it. =)

Thanks for this nice plugin, @weswigham.