### PR TITLE
Updated highlight.js dependency to 9.5.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "metalsmith-metallic",
   "description": "A Metalsmith plugin to hightlight code blocks in markdown using highlight.js.",
   "repository": "git://github.com/weswigham/metalsmith-metallic.git",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "license": "MIT",
   "main": "lib/index.js",
   "scripts": {
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "debug": "~2.1",
-    "highlight.js": "~8.9.1",
+    "highlight.js": "~9.5.0",
     "entities": "~1.1"
   },
   "devDependencies": {

--- a/test/fixture/build/csharp.md
+++ b/test/fixture/build/csharp.md
@@ -1,10 +1,10 @@
 <pre><code class="hljs csharp"><span class="hljs-keyword">using</span> System;
 
-<span class="hljs-preprocessor">#<span class="hljs-keyword">pragma</span> <span class="hljs-keyword">warning</span> disable 414, 3021</span>
+<span class="hljs-meta">#<span class="hljs-meta-keyword">pragma</span> <span class="hljs-meta-keyword">warning</span> disable 414, 3021</span>
 
 <span class="hljs-keyword">public</span> <span class="hljs-keyword">class</span> <span class="hljs-title">Program</span>
 {
-    <span class="hljs-comment"><span class="hljs-xmlDocTag">///</span> <span class="hljs-xmlDocTag">&lt;summary&gt;</span>The entry point to the program.<span class="hljs-xmlDocTag">&lt;/summary&gt;</span></span>
+    <span class="hljs-comment"><span class="hljs-doctag">///</span> <span class="hljs-doctag">&lt;summary&gt;</span>The entry point to the program.<span class="hljs-doctag">&lt;/summary&gt;</span></span>
     <span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-keyword">static</span> <span class="hljs-keyword">int</span> <span class="hljs-title">Main</span>(<span class="hljs-params"><span class="hljs-keyword">string</span>[] args</span>)
     </span>{
         Console.WriteLine(<span class="hljs-string">"Hello, World!"</span>);

--- a/test/fixture/expected/csharp.md
+++ b/test/fixture/expected/csharp.md
@@ -1,10 +1,10 @@
 <pre><code class="hljs csharp"><span class="hljs-keyword">using</span> System;
 
-<span class="hljs-preprocessor">#<span class="hljs-keyword">pragma</span> <span class="hljs-keyword">warning</span> disable 414, 3021</span>
+<span class="hljs-meta">#<span class="hljs-meta-keyword">pragma</span> <span class="hljs-meta-keyword">warning</span> disable 414, 3021</span>
 
 <span class="hljs-keyword">public</span> <span class="hljs-keyword">class</span> <span class="hljs-title">Program</span>
 {
-    <span class="hljs-comment"><span class="hljs-xmlDocTag">///</span> <span class="hljs-xmlDocTag">&lt;summary&gt;</span>The entry point to the program.<span class="hljs-xmlDocTag">&lt;/summary&gt;</span></span>
+    <span class="hljs-comment"><span class="hljs-doctag">///</span> <span class="hljs-doctag">&lt;summary&gt;</span>The entry point to the program.<span class="hljs-doctag">&lt;/summary&gt;</span></span>
     <span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-keyword">static</span> <span class="hljs-keyword">int</span> <span class="hljs-title">Main</span>(<span class="hljs-params"><span class="hljs-keyword">string</span>[] args</span>)
     </span>{
         Console.WriteLine(<span class="hljs-string">"Hello, World!"</span>);


### PR DESCRIPTION
This updates the highlight.js dependency to the latest version, 9.5.0. I also updated a test fixture to account for changes in generated markup.

Because markup generated by this version of highlight.js might be backwards-incompatible with existing sites (which would need to update their hljs stylesheet), I updated the metalsmith-metallic version to 2.0.0.

Thanks!