### PR TITLE
Update debug package

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "debug": "~2.2",
+    "debug": "~2.6.7",
     "highlight.js": "~9.7.0",
     "entities": "~1.1"
   },


### PR DESCRIPTION
2.6.7 or higher is required to fix a ReDoS issue in `ms` - see https://snyk.io/vuln/npm:ms:20170412